### PR TITLE
feat: handle form submission

### DIFF
--- a/Main.jsx
+++ b/Main.jsx
@@ -14,21 +14,22 @@ export default function Main() {
         setRecipe(recipeMarkdown)
     }
 
-    function addIngredient(formData) {
-        const newIngredient = formData.get("ingredient")
+    function handleSubmit(event) {
+        event.preventDefault()
+        const newIngredient = event.target.elements.ingredient.value
         setIngredients(prevIngredients => [...prevIngredients, newIngredient])
     }
 
     return (
         <main>
-            <form action={addIngredient} className="add-ingredient-form">
+            <form onSubmit={handleSubmit} className="add-ingredient-form">
                 <input
                     type="text"
                     placeholder="e.g. oregano"
                     aria-label="Add ingredient"
                     name="ingredient"
                 />
-                <button>Add ingredient</button>
+                <button type="submit">Add ingredient</button>
             </form>
 
             {ingredients.length > 0 &&


### PR DESCRIPTION
## Summary
- use `handleSubmit` to process ingredient additions
- prevent default form submission and update ingredient list
- ensure add button submits the form

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1fdb1bf18832c8110c84629cb0460